### PR TITLE
fix: add runtime.getRandomData import for tinygo v0.37.0+

### DIFF
--- a/cmd/workers-assets-gen/assets/wasm_exec_tinygo.js
+++ b/cmd/workers-assets-gen/assets/wasm_exec_tinygo.js
@@ -296,6 +296,11 @@
 						return BigInt((timeOrigin + performance.now()) * 1e6);
 					},
 
+					// func getRandomData(r []byte)
+					"runtime.getRandomData": (slice_ptr, slice_len, slice_cap) => {
+						crypto.getRandomValues(loadSlice(slice_ptr, slice_len, slice_cap));
+					},
+
 					// func sleepTicks(timeout int64)
 					"runtime.sleepTicks": (timeout) => {
 						// Do not sleep, only reactivate scheduler after the given timeout.


### PR DESCRIPTION
TinyGo v0.37.0 updated the net submodule (tinygo-org/net) which introduced
a call to runtime.getRandomData in the compiled wasm binary. Without a
corresponding JS implementation in the gojs import object, instantiating
the module throws:

  LinkError: WebAssembly.Instance(): Import # 17 "gojs" "runtime.getRandomData":
  function import requires a callable

The addition is already present at the official go runtime package, though the same is missing on TinyGo.

Corresponding PR on TinyGo: [https://github.com/tinygo-org/tinygo/pull/5363](https://github.com/tinygo-org/tinygo/pull/5363).