### PR TITLE
templates/worker-tinygo: make /echo work under wrangler dev

### DIFF
--- a/_templates/cloudflare/worker-tinygo/main.go
+++ b/_templates/cloudflare/worker-tinygo/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 
@@ -13,7 +14,15 @@ func main() {
 		w.Write([]byte(msg))
 	})
 	http.HandleFunc("/echo", func(w http.ResponseWriter, req *http.Request) {
-		io.Copy(w, req.Body)
+		// Read the whole body first: io.Copy(w, req.Body) would pass the raw
+		// request ReadableStream through to the JS Response, which fails under
+		// `wrangler dev` (miniflare) with "Body has already been used".
+		// See https://github.com/syumai/workers/issues/176.
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			panic(err)
+		}
+		io.Copy(w, bytes.NewReader(b))
 	})
 	workers.Serve(nil) // use http.DefaultServeMux
 }


### PR DESCRIPTION
## Summary

The `worker-tinygo` template's `/echo` endpoint fails under `wrangler dev` with:

```
TypeError: Body has already been used. It can only be used once. Use tee() first if you need to read it twice.
```

This PR fixes the template so it works out of the box, and documents why in a comment. Fixes #176.

## Root cause

`io.Copy(w, req.Body)` triggers `readableStreamToReadCloser.WriteTo`'s fast path in `internal/jsutil/stream.go`, which passes the request's **raw ReadableStream** through to the JS `Response` object via `WriteRawJSBody`.

This zero-copy passthrough is valid on production workerd, but miniflare routes every request through a proxy worker (`miniflare/dist/src/workers/core/entry.worker.js`), and that layer cannot relay a response whose body is the incoming request's own stream — `await service.fetch(request)` throws the error above.

This is an environment limitation, not a bug in this library. A plain JavaScript worker reproduces it under `wrangler dev` with no Go involved:

```js
export default {
  async fetch(req) {
    return new Response(req.body); // same TypeError under wrangler dev
  },
};
```

(Related: cloudflare/workers-sdk#4373, another "streams work in production but not in miniflare" case.)

Since `wrangler dev` is the first thing every new user of the template runs, the template shouldn't rely on the passthrough. The `worker-go` template already buffers the body in `/echo`, which is why only the tinygo template was affected; this change aligns the two.

## Testing

Verified with TinyGo 0.41.1 + wrangler 4.124.0 (and wrangler 3.109) on macOS:

```console
$ curl -X POST -d "test message" http://localhost:8787/echo
# before: TypeError: Body has already been used. ... (HTTP 500)
# after:  test message
```

`/hello` unaffected.
