### PR TITLE
Add release workflow placeholder for workflow_dispatch registration (#173)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+
+# Placeholder so that GitHub registers this workflow: workflow_dispatch can
+# only be triggered for workflows that exist on the default branch, but the
+# dispatched run itself uses the workflow file from the selected branch.
+# The real release workflow (tagpr + mirror sync, see #173) lands on main
+# together with the module rename.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: workers-go tag to (re-)sync to the mirror
+        required: true
+        type: string
+      dry_run:
+        description: Sync the current checkout to MIRROR_REPO instead of a published tag
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This is a placeholder; run this workflow from the rename branch (see #173)."


### PR DESCRIPTION
GitHub only lets `workflow_dispatch` trigger workflows that exist on the default branch, while the dispatched run uses the workflow file from the selected branch. This adds a no-op placeholder `release.yml` so the real release workflow on the `rename-workers-go` branch can be dry-run against the scratch mirror repository before the rename (#173).

The placeholder has no `push` trigger, so nothing runs on merge. The real workflow (tagpr + mirror sync) replaces it when the rename branch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)