### PR TITLE
release: make the module proxy wait diagnosable and longer (#173)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,20 +101,30 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # proxy.golang.org fetches a version from origin the first time it is
+      # asked for it, and caches a "not found" answer for a while if that
+      # first request races the tag push. So: first make sure the tag is
+      # visible on GitHub at all, then poll the proxy for up to 30 minutes,
+      # printing the actual error so a stuck run can be diagnosed.
       - name: Wait for the tag to be resolvable via the Go module proxy
         if: steps.sync_target.outputs.tag != '' && inputs.dry_run != true
         env:
           TAG: ${{ steps.sync_target.outputs.tag }}
         run: |
-          for i in $(seq 1 60); do
-            if GOPROXY=https://proxy.golang.org GOFLAGS=-mod=mod go list -m "github.com/syumai/workers-go@${TAG}" >/dev/null 2>&1; then
-              echo "github.com/syumai/workers-go@${TAG} is resolvable."
+          if [ -z "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]; then
+            echo "::error::Tag ${TAG} does not exist on ${{ github.repository }}."
+            exit 1
+          fi
+          echo "Tag ${TAG} is visible on GitHub."
+          for i in $(seq 1 180); do
+            if out=$(GOPROXY=https://proxy.golang.org GOFLAGS=-mod=mod go list -m "github.com/syumai/workers-go@${TAG}" 2>&1); then
+              echo "github.com/syumai/workers-go@${TAG} is resolvable: ${out}"
               exit 0
             fi
-            echo "Waiting for github.com/syumai/workers-go@${TAG} to be resolvable via proxy.golang.org (attempt $i/60)..."
+            echo "attempt $i/180: ${out##*$'\n'}"
             sleep 10
           done
-          echo "::error::github.com/syumai/workers-go@${TAG} did not become resolvable within 10 minutes."
+          echo "::error::github.com/syumai/workers-go@${TAG} did not become resolvable via proxy.golang.org within 30 minutes."
           exit 1
 
       # The mirror is pushed to directly (git over SSH), not through the


### PR DESCRIPTION
The first v0.35.0 release run sat in "Waiting for github.com/syumai/workers-go@v0.35.0 to be resolvable" for the whole 10-minute budget even though the tag existed, because the request raced the tag push and proxy.golang.org cached the negative answer for a while. The step also swallowed the error output, so this could not be diagnosed from the log.

- Verify the tag is visible on GitHub before polling the proxy.
- Print the last line of the `go list -m` error on every attempt.
- Poll for up to 30 minutes instead of 10.

Part of #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)