### PR TITLE
docs: refer to the module as workers-go and add migration notes (#173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# workers
+# workers-go
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/syumai/workers-go.svg)](https://pkg.go.dev/github.com/syumai/workers-go)
 [![Discord Server](https://img.shields.io/discord/1095344956421447741?logo=discord&style=social)](https://discord.gg/tYhtatRqGs)
 
-* `workers` is a package to run an HTTP server written in Go on [Cloudflare Workers](https://workers.cloudflare.com/).
+* `workers-go` is a Go module to run an HTTP server written in Go on [Cloudflare Workers](https://workers.cloudflare.com/). Its root package is `workers`.
 * This package can easily serve *http.Handler* on Cloudflare Workers.
 * Caution: This is an experimental project.
 
@@ -39,6 +39,18 @@
 
 ```
 go get github.com/syumai/workers-go
+```
+
+### Migrating from `github.com/syumai/workers`
+
+This module was published as `github.com/syumai/workers` up to v0.34.0 and was renamed to `github.com/syumai/workers-go` in v0.35.0 ([#173](https://github.com/syumai/workers-go/issues/173)). The old path still works: it is now a thin forwarding module that re-exports this module's API and follows its releases for a transition period, but it is marked deprecated. To switch, rewrite the import paths and tidy:
+
+```
+# Linux
+find . \( -name '*.go' -o -name go.mod \) -exec sed -i 's|github.com/syumai/workers|github.com/syumai/workers-go|g' {} +
+# macOS
+find . \( -name '*.go' -o -name go.mod \) -exec sed -i '' 's|github.com/syumai/workers|github.com/syumai/workers-go|g' {} +
+go mod tidy
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ This module was published as `github.com/syumai/workers` up to v0.34.0 and was r
 
 ```
 # Linux
-find . \( -name '*.go' -o -name go.mod \) -exec sed -i 's|github.com/syumai/workers|github.com/syumai/workers-go|g' {} +
+find . \( -name '*.go' -o -name go.mod \) -exec sed -i 's|github.com/syumai/workers\([/" ]\)|github.com/syumai/workers-go\1|g' {} +
 # macOS
-find . \( -name '*.go' -o -name go.mod \) -exec sed -i '' 's|github.com/syumai/workers|github.com/syumai/workers-go|g' {} +
+find . \( -name '*.go' -o -name go.mod \) -exec sed -i '' 's|github.com/syumai/workers\([/" ]\)|github.com/syumai/workers-go\1|g' {} +
 go mod tidy
 ```
 

--- a/_examples/r2-image-viewer/main.go
+++ b/_examples/r2-image-viewer/main.go
@@ -20,8 +20,8 @@ func handleErr(w http.ResponseWriter, msg string, err error) {
 	w.Write([]byte(msg))
 }
 
-// This example is based on implementation in syumai/workers-go-playground
-//   - https://github.com/syumai/workers-go-playground/blob/e32881648ccc055e3690a0d9c750a834261c333e/r2-image-viewer/src/index.ts#L30
+// This example is based on implementation in syumai/workers-playground
+//   - https://github.com/syumai/workers-playground/blob/e32881648ccc055e3690a0d9c750a834261c333e/r2-image-viewer/src/index.ts#L30
 func handler(w http.ResponseWriter, req *http.Request) {
 	bucket, err := r2.NewBucket(bucketName)
 	if err != nil {

--- a/_templates/browser/browser-go/README.md
+++ b/_templates/browser/browser-go/README.md
@@ -2,7 +2,7 @@
 
 - A template for starting a browser-based HTTP server with Go.
   - This template uses Cloudflare Workers to just serve a static page.
-- This template uses [`workers`](https://github.com/syumai/workers-go) package to run an HTTP server.
+- This template uses [`workers-go`](https://github.com/syumai/workers-go) package to run an HTTP server.
 
 ## Usage
 

--- a/_templates/cloudflare/pages-tinygo/README.md
+++ b/_templates/cloudflare/pages-tinygo/README.md
@@ -1,7 +1,7 @@
 # pages-tinygo
 
 - A template for starting a Cloudflare Pages Functions project with tinygo.
-- This template uses the [`workers`](https://github.com/syumai/workers-go) package to run.
+- This template uses the [`workers-go`](https://github.com/syumai/workers-go) package to run.
 
 ## Usage
 

--- a/_templates/cloudflare/worker-go/README.md
+++ b/_templates/cloudflare/worker-go/README.md
@@ -1,7 +1,7 @@
 # worker-template-go
 
 - A template for starting a Cloudflare Worker project with Go.
-- This template uses [`workers`](https://github.com/syumai/workers-go) package to run an HTTP server.
+- This template uses [`workers-go`](https://github.com/syumai/workers-go) package to run an HTTP server.
 
 ## Notice
 

--- a/_templates/cloudflare/worker-tinygo/README.md
+++ b/_templates/cloudflare/worker-tinygo/README.md
@@ -1,7 +1,7 @@
 # worker-template-tinygo
 
 - A template for starting a Cloudflare Worker project with tinygo.
-- This template uses [`workers`](https://github.com/syumai/workers-go) package to run an HTTP server.
+- This template uses [`workers-go`](https://github.com/syumai/workers-go) package to run an HTTP server.
 
 ## Usage
 

--- a/mirror/README.md
+++ b/mirror/README.md
@@ -29,13 +29,13 @@ will be overwritten by the next sync. File issues and pull requests against
 Update your import paths from `github.com/syumai/workers` to `github.com/syumai/workers-go`:
 
 ```sh
-sed -i 's|github.com/syumai/workers|github.com/syumai/workers-go|g' $(grep -rl 'github.com/syumai/workers' --include='*.go' .)
+sed -i 's|github.com/syumai/workers\([/" ]\)|github.com/syumai/workers-go\1|g' $(grep -rl 'github.com/syumai/workers' --include='*.go' --include='go.mod' .)
 ```
 
 On macOS, `sed -i` requires an explicit (possibly empty) backup suffix argument:
 
 ```sh
-sed -i '' 's|github.com/syumai/workers|github.com/syumai/workers-go|g' $(grep -rl 'github.com/syumai/workers' --include='*.go' .)
+sed -i '' 's|github.com/syumai/workers\([/" ]\)|github.com/syumai/workers-go\1|g' $(grep -rl 'github.com/syumai/workers' --include='*.go' --include='go.mod' .)
 ```
 
 Then update `go.mod`/`go.sum`:


### PR DESCRIPTION
- README title and description now say `workers-go` (the Go package name stays `workers`, so code samples are unchanged).
- Adds a "Migrating from `github.com/syumai/workers`" section under Installation explaining that the old path is a deprecated forwarding module and how to rewrite imports.
- Template READMEs link to `workers-go` by name.

Part of #173 (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)