### PR TITLE
docs: drop the Worker size limit note

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ To deploy a Worker, the following steps are required.
 
 The [worker-go template](https://github.com/syumai/workers-go/tree/main/_templates/cloudflare/worker-go) contains all the required files, so I recommend using this template.
 
-But Go (not TinyGo) with many dependencies may exceed the size limit of the Worker (3MB for free plan, 10MB for paid plan). In that case, you can use the [TinyGo template](https://github.com/syumai/workers-go/tree/main/_templates/cloudflare/worker-tinygo) instead.
+But Go (not TinyGo) with many dependencies may exceed the size limit of the Worker (64 MiB uncompressed, on all plans). In that case, you can use the [TinyGo template](https://github.com/syumai/workers-go/tree/main/_templates/cloudflare/worker-tinygo) instead.
 
 The TinyGo template requires TinyGo 0.42.0 or later. TinyGo 0.41.x cannot build `net/http` for Wasm (see [tinygo-org/tinygo#5350](https://github.com/tinygo-org/tinygo/issues/5350)).
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ To deploy a Worker, the following steps are required.
 
 The [worker-go template](https://github.com/syumai/workers-go/tree/main/_templates/cloudflare/worker-go) contains all the required files, so I recommend using this template.
 
-But Go (not TinyGo) with many dependencies may exceed the size limit of the Worker (64 MiB uncompressed, on all plans). In that case, you can use the [TinyGo template](https://github.com/syumai/workers-go/tree/main/_templates/cloudflare/worker-tinygo) instead.
+If you want a smaller Wasm binary, you can use the [TinyGo template](https://github.com/syumai/workers-go/tree/main/_templates/cloudflare/worker-tinygo) instead.
 
 The TinyGo template requires TinyGo 0.42.0 or later. TinyGo 0.41.x cannot build `net/http` for Wasm (see [tinygo-org/tinygo#5350](https://github.com/tinygo-org/tinygo/issues/5350)).
 

--- a/_templates/cloudflare/worker-go/README.md
+++ b/_templates/cloudflare/worker-go/README.md
@@ -5,7 +5,7 @@
 
 ## Notice
 
-- Go (not TinyGo) with many dependencies may exceed the size limit of the Worker (64 MiB uncompressed, on all plans). In that case, you can use the [TinyGo template](https://github.com/syumai/workers-go/tree/main/_templates/cloudflare/worker-tinygo) instead.
+- If you want a smaller Wasm binary, you can use the [TinyGo template](https://github.com/syumai/workers-go/tree/main/_templates/cloudflare/worker-tinygo) instead.
 
 ## Usage
 

--- a/_templates/cloudflare/worker-go/README.md
+++ b/_templates/cloudflare/worker-go/README.md
@@ -5,7 +5,7 @@
 
 ## Notice
 
-- Go (not TinyGo) with many dependencies may exceed the size limit of the Worker (3MB for free plan, 10MB for paid plan). In that case, you can use the [TinyGo template](https://github.com/syumai/workers-go/tree/main/_templates/cloudflare/worker-tinygo) instead.
+- Go (not TinyGo) with many dependencies may exceed the size limit of the Worker (64 MiB uncompressed, on all plans). In that case, you can use the [TinyGo template](https://github.com/syumai/workers-go/tree/main/_templates/cloudflare/worker-tinygo) instead.
 
 ## Usage
 


### PR DESCRIPTION
Cloudflare removed the compressed-size check and now only limits the uncompressed bundle size to 64 MiB on all plans (see the [changelog](https://developers.cloudflare.com/changelog/post/2026-09-04-increased-worker-size-limit/)). Go Workers rarely reach this limit, so this PR removes the size-limit note from the docs while keeping the pointer to the TinyGo template for those who want a smaller Wasm binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)